### PR TITLE
Handle PyG proxy failures in notebook install cell

### DIFF
--- a/NPM3D_PanopticSeg_embeddings_and_eval.ipynb
+++ b/NPM3D_PanopticSeg_embeddings_and_eval.ipynb
@@ -1,233 +1,765 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 5,
-  "metadata": {
-    "colab": {
-      "name": "NPM3D_PanopticSeg_embeddings_and_eval.ipynb",
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.x"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a4f1277a",
+   "metadata": {},
+   "source": [
+    "# NPM3D Panoptic Segmentation — embeddings + eval (ETH pipeline)\n",
+    "\n",
+    "**Repo**: fork of `prs-eth/PanopticSegForLargeScalePointCloud`.\n",
+    "\n",
+    "Ce notebook Colab installe l'environnement, récupère NPM3D (avec labels d'instances),\n",
+    "lance l'entraînement/éval avec les configs des auteurs, **extrait les embeddings 5D** avant le clustering,\n",
+    "et calcule les métriques officielles (F1 / PQ / etc.).\n",
+    "\n",
+    "⚙️ GPU requis (Colab Pro conseillé)."
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# NPM3D Panoptic Segmentation — embeddings + eval (ETH pipeline)\n\n**Repo**: fork of `prs-eth/PanopticSegForLargeScalePointCloud`.\n\nCe notebook Colab installe l'environnement, récupère NPM3D (avec labels d'instances),\nlance l'entraînement/éval avec les configs des auteurs, **extrait les embeddings 5D** avant le clustering,\net calcule les métriques officielles (F1 / PQ / etc.).\n\n⚙️ GPU requis (Colab Pro conseillé)."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## 1) Vérifier le GPU"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "cellView": "form"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "\nimport os, subprocess, sys, platform, torch\n# torch may not be installed yet; guard\ntry:\n    import torch\n    print(\"Torch version:\", torch.__version__)\n    print(\"CUDA available:\", torch.cuda.is_available())\n    if torch.cuda.is_available():\n        print(\"CUDA device:\", torch.cuda.get_device_name(0))\nexcept Exception as e:\n    print(\"Torch not yet installed:\", e)\n!nvidia-smi || true\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## 2) Dépendances système (OpenBLAS pour MinkowskiEngine)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "cellView": "form"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "\n%%bash\nset -euxo pipefail\nsudo apt-get update -y\nsudo apt-get install -y build-essential git cmake libopenblas-dev libomp-dev\n# Optional but useful for large builds\nsudo apt-get install -y ninja-build\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## 3) PyTorch 1.9.0 (cu111) + PyG wheels (compatibles) + MinkowskiEngine\nLes auteurs indiquent PyTorch 1.9.0 + cu111, torch-scatter/sparse correspondants et MinkowskiEngine compilé **avec OpenBLAS**."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "cellView": "form"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "\n    %%bash\n    set -euxo pipefail\n    # Désinstaller torch/torchvision existants\n    pip uninstall -y torch torchvision torchaudio || true\n\n    # Installer torch 1.9.0 + cu111 et torchvision 0.10.0 + cu111\n    pip install --no-cache-dir torch==1.9.0+cu111 torchvision==0.10.0+cu111 \\\n        -f https://download.pytorch.org/whl/torch_stable.html\n\n    python - << 'PY'\nimport torch, sys\nprint(\"Torch:\", torch.__version__, \"CUDA ok:\", torch.cuda.is_available())\nassert torch.__version__.startswith(\"1.9\"), \"Torch 1.9.x requis\"\nPY\n\n    # PyG wheels compatibles avec torch 1.9.0+cu111\n    pip install --no-cache-dir torch-scatter==2.0.8 -f https://data.pyg.org/whl/torch-1.9.0+cu111.html\n    pip install --no-cache-dir torch-sparse==0.6.12 -f https://data.pyg.org/whl/torch-1.9.0+cu111.html\n    pip install --no-cache-dir torch-geometric==1.7.2\n\n    # Dépendances Python supplémentaires\n    pip install --no-cache-dir hydra-core==1.1.0 omegaconf==2.1.0 plyfile==0.8.1 \\\n        scipy==1.7.3 hdbscan==0.8.27 pandas==1.3.5 numba==0.55.1 joblib==1.1.0 tqdm pyyaml\n\n    # MinkowskiEngine depuis source (OpenBLAS)\n    # Rem: Colab a souvent /usr/include pour cblas.h via libopenblas-dev\n    git clone --depth=1 https://github.com/NVIDIA/MinkowskiEngine.git\n    pushd MinkowskiEngine\n    python setup.py install --blas_include_dirs=/usr/include --blas=openblas\n    popd\n\n    python - << 'PY'\ntry:\n    import MinkowskiEngine as ME\n    print(\"MinkowskiEngine:\", ME.__version__)\nexcept Exception as e:\n    raise SystemExit(\"Echec import MinkowskiEngine: %s\" % e)\nPY\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## 4) Cloner votre fork et préparer l'arborescence"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "cellView": "form"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "\n%%bash\nset -euxo pipefail\nREPO_URL=\"https://github.com/Ludwig-H/PanopticSegForLargeScalePointCloud\"\nif [ ! -d PanopticSegForLargeScalePointCloud ]; then\n  git clone --depth=1 \"$REPO_URL\"\nfi\ncd PanopticSegForLargeScalePointCloud\n# Créer dossiers de données selon README\nmkdir -p data/npm3dfused/raw\nmkdir -p outputs\necho \"Repo ready.\"\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## 5) Télécharger NPM3D (avec labels d’instances)\nSource officielle Zenodo `10.5281/zenodo.8118986`. Les fichiers .ply sont posés dans `data/npm3dfused/raw/`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "cellView": "form"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "\n%%bash\nset -euxo pipefail\ncd PanopticSegForLargeScalePointCloud/data/npm3dfused/raw\n\nbase=\"https://zenodo.org/records/8118986/files\"\n\nfiles=(\n  \"Paris_train.ply\"\n  \"Paris_val.ply\"\n  \"Paris_test.ply\"\n  \"Lille1_1_train.ply\"\n  \"Lille1_1_val.ply\"\n  \"Lille1_1_test.ply\"\n  \"Lille1_2_train.ply\"\n  \"Lille1_2_val.ply\"\n  \"Lille1_2_test.ply\"\n  \"Lille2_train.ply\"\n  \"Lille2_val.ply\"\n  \"Lille2_test.ply\"\n)\n\nfor f in \"${files[@]}\"; do\n  if [ ! -f \"$f\" ]; then\n    echo \"Downloading $f\"\n    wget -q --show-progress \"${base}/${f}?download=1\" -O \"$f\"\n  else\n    echo \"Already have $f\"\n  fi\ndone\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## 6) (Optionnel) Entraînement NPM3D — même config que le papier\nLes auteurs donnent en exemple Setting **IV** pour `area1`:\n\n```bash\npython train.py task=panoptic \\\n  data=panoptic/npm3d-sparseconv_grid_012_R_16_cylinder_area1 \\\n  models=panoptic/area4_ablation_3heads_5 model_name=PointGroup-PAPER \\\n  training=7_area1 job_name=A1_S7\n```\nTu peux boucler sur `area{1..4}` pour faire le 4-fold.\nMet `WANDB_MODE=offline` pour éviter la synchro en ligne."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "cellView": "form"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "\n%%bash\nset -euxo pipefail\ncd PanopticSegForLargeScalePointCloud\n\nexport WANDB_MODE=offline\n# Dé-commenter pour lancer un entraînement complet pour area1 (coûteux).\n# python train.py task=panoptic \\\n#   data=panoptic/npm3d-sparseconv_grid_012_R_16_cylinder_area1 \\\n#   models=panoptic/area4_ablation_3heads_5 model_name=PointGroup-PAPER \\\n#   training=7_area1 job_name=A1_S7\necho \"Entraînement désactivé par défaut (trop long en Colab).\"\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## 7) Extraire les **embeddings 5D** avant clustering\nOn attache un **forward hook** sur la branche d'embedding du modèle pendant l'éval.\nLe script ci-dessous:\n- charge la config Hydra d'éval, le checkpoint, et le dataloader test (mêmes scènes),\n- capture les embeddings par point et les enregistre en `.npz` par bloc.\n\nIl essaie d'abord des clés de sortie usuelles (`embedding`, `embeddings`, `embedding_5d`),\npuis cherche un module dont le nom contient `emb` pour y accrocher un hook si besoin."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "cellView": "form"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "\n%%bash\nset -euxo pipefail\ncd PanopticSegForLargeScalePointCloud\n\ncat > tools_extract_embeddings.py << 'PY'\nimport os, sys, glob, json, re, pathlib, numpy as np, torch\nfrom pathlib import Path\nfrom omegaconf import OmegaConf\nsys.path.append(str(Path.cwd()))\n# Import TP3D local copy\nsys.path.append(str(Path.cwd() / \"torch_points3d\"))\nfrom torch_points3d.metrics.panoptic_tracker import PanopticTracker  # noqa: F401 (forces TP3D import)\nfrom train import hydra_main as train_hydra_main  # to reuse config utils if exposed\nfrom eval import hydra_main as eval_hydra_main    # type: ignore\n\n# Small utility to load hydra config from conf/eval.yaml\ndef load_eval_cfg():\n    cfg = OmegaConf.load(\"conf/eval.yaml\")\n    return cfg\n\ndef find_embed_module(model):\n    candidates = []\n    for name, m in model.named_modules():\n        if \"emb\" in name.lower():\n            candidates.append(name)\n    return candidates\n\ndef ensure_dir(p): os.makedirs(p, exist_ok=True)\n\ndef dump_npz(out_dir, tag, data_dict):\n    ensure_dir(out_dir)\n    np.savez_compressed(os.path.join(out_dir, f\"{tag}.npz\"), **data_dict)\n\ndef main():\n    import hydra\n    from omegaconf import DictConfig\n    # Run eval hydra to build model + dataloaders then intercept forward\n    @hydra.main(config_path=\"conf\", config_name=\"eval\", version_base=None)\n    def _run(cfg: DictConfig):\n        # Build model & loaders the same way eval.py does\n        # We call the eval hydra entry but override the evaluation loop to attach hooks.\n        from eval import build_model_and_loaders  # we expect eval.py to expose helpers; fallback otherwise\n        try:\n            model, loaders, device, test_split = build_model_and_loaders(cfg)\n        except Exception as e:\n            print(\"Falling back to importing torch_points3d style builders:\", e)\n            # Fallback: try to import internal builders if authors changed names\n            raise\n\n        model.eval()\n        model = model.to(device)\n\n        # Try to discover an embedding head via outputs or module names\n        caught = {\"batch_indices\": [], \"embeddings\": []}\n        example_name = None\n\n        # Soft hook mechanism\n        chosen_mod = None\n        for name, m in model.named_modules():\n            if re.search(r\"(emb|embed|embedding)\", name, re.I):\n                chosen_mod = m\n                chosen_name = name\n                break\n        hook_handle = None\n        if chosen_mod is not None:\n            def _hook(module, inp, out):\n                # out shape [N, D]\n                try:\n                    E = out.detach().cpu().float().numpy()\n                    caught[\"embeddings\"].append(E)\n                except Exception:\n                    pass\n            hook_handle = chosen_mod.register_forward_hook(lambda m,i,o: _hook(m,i,o))\n            print(f\"[extract] Hooked embedding module: {chosen_name}\", flush=True)\n        else:\n            print(\"[extract] No obvious embedding module found; will try dict outputs.\", flush=True)\n\n        out_root = Path(\"outputs/embeddings\")\n        ensure_dir(out_root)\n\n        # Iterate over test loader only\n        test_loader = loaders.get(test_split, None) or loaders.get(\"test\", None)\n        if test_loader is None:\n            raise RuntimeError(\"Test loader not found in loaders keys:\", loaders.keys())\n\n        with torch.no_grad():\n            for ib, batch in enumerate(test_loader):\n                batch = batch.to(device)\n                out = model(batch)\n                # If model returns dict with embeddings\n                if isinstance(out, dict):\n                    for k in [\"embedding\", \"embeddings\", \"embedding_5d\", \"emb_5d\", \"panoptic_embeddings\"]:\n                        if k in out and isinstance(out[k], torch.Tensor):\n                            E = out[k].detach().cpu().float().numpy()\n                            caught[\"embeddings\"].append(E)\n                            break\n\n                # Gather point indices to map back if available\n                if hasattr(batch, \"idx\"):\n                    idx = batch.idx.detach().cpu().numpy()\n                elif hasattr(batch, \"ptr\"):\n                    idx = batch.ptr.detach().cpu().numpy()\n                else:\n                    # fallback: monotonic indices\n                    n = out[\"semantic\"].shape[0] if isinstance(out, dict) and \"semantic\" in out else 0\n                    idx = np.arange(n, dtype=np.int64)\n\n                # Flatten and dump per-batch\n                if len(caught[\"embeddings\"]) == 0:\n                    print(f\"[extract] WARNING: no embeddings captured for batch {ib}.\")\n                    continue\n                E = caught[\"embeddings\"][-1]\n                tag = f\"batch_{ib:05d}\"\n                dump_npz(out_root, tag, {\"indices\": idx, \"embeddings\": E})\n                print(f\"[extract] Saved embeddings for {tag} -> {E.shape}\", flush=True)\n\n        if hook_handle is not None:\n            hook_handle.remove()\n\n    _run()\n\nif __name__ == \"__main__\":\n    main()\nPY\n\necho \"Script tools_extract_embeddings.py created.\"\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## 8) Exécuter l'évaluation et l’extraction d’embeddings\nLe script d’éval officiel produit les dossiers `viz_for_test_*`. Ensuite, on extrait les embeddings en suivant **les mêmes splits/scènes**.\n\n**Remarque:** pense à mettre le chemin du checkpoint (`CKPT_PATH`) si tu n’entraînes pas dans cette session."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "cellView": "form"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "\n%%bash\nset -euxo pipefail\ncd PanopticSegForLargeScalePointCloud\n\n# Exemple: on veut évaluer Area 1 (Paris en test) en Setting IV (comme dans README)\n# Si tu as entraîné ici, adapte CKPT_PATH en conséquence; sinon, place un checkpoint existant à l'endroit indiqué.\nCKPT_PATH=\"${CKPT_PATH:-/content/drive/MyDrive/panoptic_runs/A1_S7/checkpoints/best.pth}\" || true\n\n# Adapter conf/eval.yaml avant de lancer eval.py (les auteurs l'indiquent dans le README).\n# Comme on ne connaît pas tes chemins exacts, on te laisse la main:\necho \"Ouvre et adapte conf/eval.yaml si nécessaire (paths, split, ckpt).\"\nsed -n '1,160p' conf/eval.yaml || true\n\n# Lancer l'éval (si eval.py dépend entièrement de conf/eval.yaml)\n# python eval.py\n\n# Ou, si Hydra accepte des overrides, tu peux donner des précisions en CLI (à adapter si besoin) :\n# python eval.py task=panoptic data=panoptic/npm3d-sparseconv_grid_012_R_16_cylinder_area1 \\\n#   models=panoptic/area4_ablation_3heads_5 model_name=PointGroup-PAPER training=7_area1 \\\n#   +eval.ckpt_path=\"$CKPT_PATH\"\n\necho \"Extraction des embeddings (utilise conf/eval.yaml et le même loader test)\"\npython tools_extract_embeddings.py || true\n\necho \"Pour calculer les métriques officielles NPM3D :\"\necho \"python evaluation_stats_NPM3D.py\"\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## 9) Où sont les embeddings et comment brancher ton clusterer\nLes `.npz` sont écrits sous `outputs/embeddings/` avec deux arrays:\n- `embeddings`: matrice `[N, 5]` (D=5 attendu) de l’embedding discriminant par point du batch\n- `indices`: indices des points pour reconstituer l’ordre si besoin\n\n### Exemple: brancher un clusterer perso qui prend soit `X` soit une matrice de distances\nLe snippet ci-dessous charge tous les `.npz`, concatène, normalise à la volée, applique un clusterer,\npuis sauvegarde un `instance_id` par point dans un `.npy`. À toi de remplacer `my_clusterer()`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "cellView": "form"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "\nimport os, glob, numpy as np\nfrom sklearn.preprocessing import StandardScaler\n\nEMB_DIR = \"PanopticSegForLargeScalePointCloud/outputs/embeddings\"\nOUT_PATH = \"PanopticSegForLargeScalePointCloud/outputs/instance_labels.npy\"\n\ndef load_all_embeddings_npz(emb_dir):\n    files = sorted(glob.glob(os.path.join(emb_dir, \"*.npz\")))\n    Xs, Is = [], []\n    for f in files:\n        d = np.load(f)\n        Xs.append(d[\"embeddings\"])\n        Is.append(d[\"indices\"])\n    if not Xs:\n        raise RuntimeError(\"Aucun fichier d'embedding trouvé dans %s\" % emb_dir)\n    X = np.concatenate(Xs, axis=0)\n    I = np.concatenate(Is, axis=0)\n    return X, I\n\ndef my_clusterer(X):\n    # TODO: remplace par ton algo. Ici, on met un stub trivial à 1 cluster.\n    # X: [N, d]\n    N = X.shape[0]\n    labels = np.zeros(N, dtype=np.int32)\n    return labels\n\nX, I = load_all_embeddings_npz(EMB_DIR)\nXn = StandardScaler().fit_transform(X)\nlabels = my_clusterer(Xn)\nnp.save(OUT_PATH, labels)\nprint(\"Saved instance labels to:\", OUT_PATH, \" shape:\", labels.shape)\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## 10) (Facultatif) Remonter tes clusters en PLY et relancer l’éval officielle\nSi tu veux remplacer les instances du pipeline par les tiennes, convertis `instance_labels.npy` en `.ply` attendu par `evaluation_stats_NPM3D.py`.\nLe format attendu par l’issue #19 indique des champs `pre_sem_label`, `gt_sem_label` et les IDs d’instance prédits/GT. Tu peux partir des sorties de `viz_for_test_valid_proposals` et ne remplacer que la colonne d’instances prédictives."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "cellView": "form"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "\n# Exemple de squelette: à adapter selon les champs déjà présents dans vos PLY de sortie\n# from plyfile import PlyData, PlyElement\n# import numpy as np\n# sem_ply = PlyData.read(\"PanopticSegForLargeScalePointCloud/viz_for_test_valid_proposals/instance.ply\")\n# labels = np.load(\"PanopticSegForLargeScalePointCloud/outputs/instance_labels.npy\")\n# # Construire une nouvelle structure en remplaçant le champ d'instance prédite puis sauvegarder.\n# PlyData([ ... ]).write(\"PanopticSegForLargeScalePointCloud/outputs/instance_custom.ply\")\nprint(\"Voir issue #19 pour les champs consultés par evaluation_stats_NPM3D.py\")\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## 11) Lancer l’évaluation finale (scripts officiels)\nLes auteurs fournissent `evaluation_stats_NPM3D.py` qui charge les sorties d’éval et calcule F1, PQ, etc."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "cellView": "form"
-      },
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "\n%%bash\nset -euxo pipefail\ncd PanopticSegForLargeScalePointCloud\n# Pour NPM3D\npython evaluation_stats_NPM3D.py || true\n# Pour FOR-instance (si utilisé)\n# python evaluation_stats_FOR.py\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Notes pratiques\n- Les chemins et le checkpoint à utiliser pour l’éval se règlent dans `conf/eval.yaml` ou via des overrides Hydra. Le README fournit les commandes et les noms des configs pour NPM3D, **Setting IV** notamment.\n- Le dataset NPM3D avec **labels d’instance** se télécharge depuis Zenodo (12 fichiers .ply). On les place sous `data/npm3dfused/raw/` comme indiqué dans le README.\n- Si l’extraction d’embeddings ne capture rien du premier coup, imprime la liste des `model.named_modules()` et choisis un module contenant `emb` pour le hook."
-      ]
-    }
-  ]
+  {
+   "cell_type": "markdown",
+   "id": "e1da94dc",
+   "metadata": {},
+   "source": [
+    "## 1) Vérifier le GPU"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a85d7ecc",
+   "metadata": {
+    "cellView": "form"
+   },
+   "outputs": [],
+   "source": [
+    "import platform\n",
+    "\n",
+    "def version_tuple(ver: str):\n",
+    "    main = ver.split(\"+\", 1)[0]\n",
+    "    parts = main.split(\".\")\n",
+    "    nums = []\n",
+    "    for part in parts:\n",
+    "        if part.isdigit():\n",
+    "            nums.append(int(part))\n",
+    "        else:\n",
+    "            digits = \"\"\n",
+    "            for ch in part:\n",
+    "                if ch.isdigit():\n",
+    "                    digits += ch\n",
+    "                else:\n",
+    "                    break\n",
+    "            if digits:\n",
+    "                nums.append(int(digits))\n",
+    "                break\n",
+    "    while len(nums) < 3:\n",
+    "        nums.append(0)\n",
+    "    return tuple(nums[:3])\n",
+    "\n",
+    "try:\n",
+    "    import torch\n",
+    "except Exception as exc:\n",
+    "    torch = None\n",
+    "    print(\"Torch non importable pour le moment:\", exc)\n",
+    "else:\n",
+    "    print(\"Torch version:\", torch.__version__)\n",
+    "    vt = version_tuple(torch.__version__)\n",
+    "    if vt < (2, 8, 0):\n",
+    "        print(\"⚠️ PyTorch >= 2.8.0 est recommandé pour ce notebook.\")\n",
+    "    print(\"CUDA available:\", torch.cuda.is_available())\n",
+    "    if torch.cuda.is_available():\n",
+    "        print(\"CUDA device:\", torch.cuda.get_device_name(0))\n",
+    "\n",
+    "!nvidia-smi || true\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62eb1b0c",
+   "metadata": {},
+   "source": [
+    "## 2) Dépendances système (OpenBLAS pour MinkowskiEngine)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9dfac574",
+   "metadata": {
+    "cellView": "form"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "%%bash\n",
+    "set -euxo pipefail\n",
+    "sudo apt-get update -y\n",
+    "sudo apt-get install -y build-essential git cmake libopenblas-dev libomp-dev\n",
+    "# Optional but useful for large builds\n",
+    "sudo apt-get install -y ninja-build\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "809d9615",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## 3) PyTorch 2.8.0 (cu126) + PyG compatibles + MinkowskiEngine\n",
+    "Ce notebook part du principe que PyTorch 2.8.0+cu126 est déjà présent dans l'environnement (par ex. `pip install torch==2.8.0+cu126` ou `pip install torch==2.8.0+cu128`).\n",
+    "La cellule suivante aligne les bibliothèques PyG compatibles, installe les dépendances Python nécessaires et (re)compile MinkowskiEngine avec OpenBLAS.\n",
+    "\n",
+    "* Tu peux surcharger l'URL des roues PyG via la variable d'environnement `PYG_INDEX_URL` si tu disposes d'un miroir interne.\n",
+    "* Si l'accès au dépôt officiel `https://data.pyg.org` est filtré (erreurs 403 via proxy, etc.), exporte `ALLOW_PYG_SOURCE_BUILD=1` avant d'exécuter la cellule pour autoriser une compilation locale depuis les sources (`torch-scatter`, `torch-sparse`, `torch-cluster`). Cette étape peut durer plus de 20 minutes sur une machine fraîche.\n",
+    "* Pense à configurer `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` selon ton infrastructure réseau pour que `pip` atteigne les dépôts distants.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9e0da165",
+   "metadata": {
+    "cellView": "form"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "    import os\n",
+    "    import shlex\n",
+    "    import subprocess\n",
+    "    import sys\n",
+    "    import urllib.error\n",
+    "    import urllib.request\n",
+    "    from pathlib import Path\n",
+    "\n",
+    "    def run(cmd, **kwargs):\n",
+    "        if isinstance(cmd, (list, tuple)):\n",
+    "            printable = \" \".join(shlex.quote(str(c)) for c in cmd)\n",
+    "        else:\n",
+    "            printable = str(cmd)\n",
+    "        print(f\"+ {printable}\")\n",
+    "        subprocess.check_call(cmd, **kwargs)\n",
+    "\n",
+    "    PYTHON = sys.executable\n",
+    "    run([PYTHON, \"-m\", \"pip\", \"install\", \"--upgrade\", \"pip\", \"wheel\", \"setuptools\"])\n",
+    "\n",
+    "    try:\n",
+    "        import torch\n",
+    "    except Exception as exc:\n",
+    "        raise SystemExit(\"Veuillez installer PyTorch 2.8.0+cu126 (ou compatible) avant d'exécuter ce notebook.\") from exc\n",
+    "\n",
+    "\n",
+    "    def version_tuple(ver: str):\n",
+    "        main = ver.split(\"+\", 1)[0]\n",
+    "        parts = main.split(\".\")\n",
+    "        nums = []\n",
+    "        for part in parts:\n",
+    "            if part.isdigit():\n",
+    "                nums.append(int(part))\n",
+    "            else:\n",
+    "                digits = \"\"\n",
+    "                for ch in part:\n",
+    "                    if ch.isdigit():\n",
+    "                        digits += ch\n",
+    "                    else:\n",
+    "                        break\n",
+    "                if digits:\n",
+    "                    nums.append(int(digits))\n",
+    "                    break\n",
+    "        while len(nums) < 3:\n",
+    "            nums.append(0)\n",
+    "        return tuple(nums[:3])\n",
+    "\n",
+    "\n",
+    "    if version_tuple(torch.__version__) < (2, 8, 0):\n",
+    "        raise SystemExit(f\"PyTorch >= 2.8.0 requis, version détectée: {torch.__version__}\")\n",
+    "\n",
+    "    print(f\"PyTorch {torch.__version__} (CUDA {torch.version.cuda or 'CPU'})\")\n",
+    "\n",
+    "    base_ver = torch.__version__.split(\"+\", 1)[0]\n",
+    "    build_suffix = torch.__version__.split(\"+\", 1)[1] if \"+\" in torch.__version__ else \"\"\n",
+    "    if build_suffix.startswith(\"cu\"):\n",
+    "        cu_tag = build_suffix\n",
+    "    else:\n",
+    "        cuda_version = torch.version.cuda.replace(\".\", \"\") if torch.version.cuda else \"\"\n",
+    "        cu_tag = f\"cu{cuda_version}\" if cuda_version else \"cpu\"\n",
+    "\n",
+    "    custom_index = os.environ.get(\"PYG_INDEX_URL\")\n",
+    "    if custom_index:\n",
+    "        pyg_index = custom_index\n",
+    "        print(f\"Index PyG forcé via $PYG_INDEX_URL: {pyg_index}\")\n",
+    "    else:\n",
+    "        if cu_tag == \"cpu\":\n",
+    "            pyg_index = f\"https://data.pyg.org/whl/torch-{base_ver}.html\"\n",
+    "        else:\n",
+    "            pyg_index = f\"https://data.pyg.org/whl/torch-{base_ver}+{cu_tag}.html\"\n",
+    "        print(f\"Index PyG calculé: {pyg_index}\")\n",
+    "\n",
+    "\n",
+    "    def pyg_index_accessible(url: str) -> bool:\n",
+    "        if not url:\n",
+    "            return False\n",
+    "        if url.startswith(\"http\"):\n",
+    "            try:\n",
+    "                with urllib.request.urlopen(url, timeout=10) as resp:\n",
+    "                    print(f\"[pyg] accès {url} -> HTTP {resp.status}\")\n",
+    "                    return 200 <= resp.status < 300\n",
+    "            except urllib.error.HTTPError as exc:\n",
+    "                print(f\"[pyg] accès {url} refusé: HTTP {exc.code} ({exc.reason}).\")\n",
+    "                return False\n",
+    "            except urllib.error.URLError as exc:\n",
+    "                print(f\"[pyg] accès {url} impossible: {exc}.\")\n",
+    "                return False\n",
+    "        else:\n",
+    "            p = Path(url)\n",
+    "            ok = p.exists()\n",
+    "            print(f\"[pyg] accès local {url}: {'ok' if ok else 'introuvable'}\")\n",
+    "            return ok\n",
+    "        return False\n",
+    "\n",
+    "\n",
+    "    run([\n",
+    "        PYTHON,\n",
+    "        \"-m\",\n",
+    "        \"pip\",\n",
+    "        \"install\",\n",
+    "        \"--no-cache-dir\",\n",
+    "        \"--upgrade\",\n",
+    "        \"hydra-core==1.3.2\",\n",
+    "        \"omegaconf==2.3.0\",\n",
+    "        \"plyfile==0.9\",\n",
+    "        \"scipy==1.11.4\",\n",
+    "        \"hdbscan==0.8.33\",\n",
+    "        \"pandas==2.2.2\",\n",
+    "        \"numba==0.59.1\",\n",
+    "        \"joblib==1.3.2\",\n",
+    "        \"tqdm\",\n",
+    "        \"pyyaml\",\n",
+    "        \"packaging\",\n",
+    "    ])\n",
+    "\n",
+    "    pyg_packages = [\n",
+    "        \"torch-scatter==2.1.2\",\n",
+    "        \"torch-sparse==0.6.18\",\n",
+    "        \"torch-cluster==1.6.3\",\n",
+    "        \"torch-geometric==2.6.1\",\n",
+    "    ]\n",
+    "\n",
+    "    wheels_available = pyg_index_accessible(pyg_index)\n",
+    "    allow_source_build = os.environ.get(\"ALLOW_PYG_SOURCE_BUILD\", \"\").strip().lower() in {\"1\", \"true\", \"yes\"}\n",
+    "    if not wheels_available and not allow_source_build:\n",
+    "        raise SystemExit(\n",
+    "            \"Impossible de télécharger les roues PyG depuis data.pyg.org.\n",
+    "\"\n",
+    "            \"Configure HTTP(S)_PROXY/NO_PROXY ou fixe $PYG_INDEX_URL vers un miroir accessible.\n",
+    "\"\n",
+    "            \"Sinon exporte ALLOW_PYG_SOURCE_BUILD=1 pour compiler les bibliothèques PyG depuis les sources (cela peut prendre\"\n",
+    "            \" 20+ minutes).\"\n",
+    "        )\n",
+    "\n",
+    "    pyg_cmd = [\n",
+    "        PYTHON,\n",
+    "        \"-m\",\n",
+    "        \"pip\",\n",
+    "        \"install\",\n",
+    "        \"--no-cache-dir\",\n",
+    "        \"--upgrade\",\n",
+    "    ]\n",
+    "    if wheels_available:\n",
+    "        pyg_cmd.extend([\"--extra-index-url\", pyg_index])\n",
+    "    else:\n",
+    "        print(\"[pyg] Compilation depuis les sources demandée (ALLOW_PYG_SOURCE_BUILD=1).\")\n",
+    "        pyg_cmd.extend([\"--no-binary\", \"torch-scatter,torch-sparse,torch-cluster\"])\n",
+    "    pyg_cmd.extend(pyg_packages)\n",
+    "    run(pyg_cmd)\n",
+    "\n",
+    "    repo_dir = Path(\"MinkowskiEngine\")\n",
+    "    if repo_dir.exists():\n",
+    "        run([\"git\", \"-C\", str(repo_dir), \"pull\", \"--ff-only\"])\n",
+    "    else:\n",
+    "        run([\"git\", \"clone\", \"--depth\", \"1\", \"https://github.com/NVIDIA/MinkowskiEngine.git\", str(repo_dir)])\n",
+    "\n",
+    "    env = os.environ.copy()\n",
+    "    env.setdefault(\"MAX_JOBS\", str(os.cpu_count() or 1))\n",
+    "    run([\n",
+    "        PYTHON,\n",
+    "        \"setup.py\",\n",
+    "        \"install\",\n",
+    "        \"--blas_include_dirs=/usr/include\",\n",
+    "        \"--blas=openblas\",\n",
+    "    ], cwd=str(repo_dir), env=env)\n",
+    "\n",
+    "    import MinkowskiEngine as ME\n",
+    "    print(\"MinkowskiEngine:\", ME.__version__)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3049e871",
+   "metadata": {},
+   "source": [
+    "## 4) Cloner votre fork et préparer l'arborescence"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "48fd2183",
+   "metadata": {
+    "cellView": "form"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "%%bash\n",
+    "set -euxo pipefail\n",
+    "REPO_URL=\"https://github.com/Ludwig-H/PanopticSegForLargeScalePointCloud\"\n",
+    "if [ ! -d PanopticSegForLargeScalePointCloud ]; then\n",
+    "  git clone --depth=1 \"$REPO_URL\"\n",
+    "fi\n",
+    "cd PanopticSegForLargeScalePointCloud\n",
+    "# Créer dossiers de données selon README\n",
+    "mkdir -p data/npm3dfused/raw\n",
+    "mkdir -p outputs\n",
+    "echo \"Repo ready.\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c98b7001",
+   "metadata": {},
+   "source": [
+    "## 5) Télécharger NPM3D (avec labels d’instances)\n",
+    "Source officielle Zenodo `10.5281/zenodo.8118986`. Les fichiers .ply sont posés dans `data/npm3dfused/raw/`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef511623",
+   "metadata": {
+    "cellView": "form"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "%%bash\n",
+    "set -euxo pipefail\n",
+    "cd PanopticSegForLargeScalePointCloud/data/npm3dfused/raw\n",
+    "\n",
+    "base=\"https://zenodo.org/records/8118986/files\"\n",
+    "\n",
+    "files=(\n",
+    "  \"Paris_train.ply\"\n",
+    "  \"Paris_val.ply\"\n",
+    "  \"Paris_test.ply\"\n",
+    "  \"Lille1_1_train.ply\"\n",
+    "  \"Lille1_1_val.ply\"\n",
+    "  \"Lille1_1_test.ply\"\n",
+    "  \"Lille1_2_train.ply\"\n",
+    "  \"Lille1_2_val.ply\"\n",
+    "  \"Lille1_2_test.ply\"\n",
+    "  \"Lille2_train.ply\"\n",
+    "  \"Lille2_val.ply\"\n",
+    "  \"Lille2_test.ply\"\n",
+    ")\n",
+    "\n",
+    "for f in \"${files[@]}\"; do\n",
+    "  if [ ! -f \"$f\" ]; then\n",
+    "    echo \"Downloading $f\"\n",
+    "    wget -q --show-progress \"${base}/${f}?download=1\" -O \"$f\"\n",
+    "  else\n",
+    "    echo \"Already have $f\"\n",
+    "  fi\n",
+    "done\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e47f3561",
+   "metadata": {},
+   "source": [
+    "## 6) (Optionnel) Entraînement NPM3D — même config que le papier\n",
+    "Les auteurs donnent en exemple Setting **IV** pour `area1`:\n",
+    "\n",
+    "```bash\n",
+    "python train.py task=panoptic \\\n",
+    "  data=panoptic/npm3d-sparseconv_grid_012_R_16_cylinder_area1 \\\n",
+    "  models=panoptic/area4_ablation_3heads_5 model_name=PointGroup-PAPER \\\n",
+    "  training=7_area1 job_name=A1_S7\n",
+    "```\n",
+    "Tu peux boucler sur `area{1..4}` pour faire le 4-fold.\n",
+    "Met `WANDB_MODE=offline` pour éviter la synchro en ligne."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "569258bd",
+   "metadata": {
+    "cellView": "form"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "%%bash\n",
+    "set -euxo pipefail\n",
+    "cd PanopticSegForLargeScalePointCloud\n",
+    "\n",
+    "export WANDB_MODE=offline\n",
+    "# Dé-commenter pour lancer un entraînement complet pour area1 (coûteux).\n",
+    "# python train.py task=panoptic \\\n",
+    "#   data=panoptic/npm3d-sparseconv_grid_012_R_16_cylinder_area1 \\\n",
+    "#   models=panoptic/area4_ablation_3heads_5 model_name=PointGroup-PAPER \\\n",
+    "#   training=7_area1 job_name=A1_S7\n",
+    "echo \"Entraînement désactivé par défaut (trop long en Colab).\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa454edc",
+   "metadata": {},
+   "source": [
+    "## 7) Extraire les **embeddings 5D** avant clustering\n",
+    "On attache un **forward hook** sur la branche d'embedding du modèle pendant l'éval.\n",
+    "Le script ci-dessous:\n",
+    "- charge la config Hydra d'éval, le checkpoint, et le dataloader test (mêmes scènes),\n",
+    "- capture les embeddings par point et les enregistre en `.npz` par bloc.\n",
+    "\n",
+    "Il essaie d'abord des clés de sortie usuelles (`embedding`, `embeddings`, `embedding_5d`),\n",
+    "puis cherche un module dont le nom contient `emb` pour y accrocher un hook si besoin."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b95f193",
+   "metadata": {
+    "cellView": "form"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "%%bash\n",
+    "set -euxo pipefail\n",
+    "cd PanopticSegForLargeScalePointCloud\n",
+    "\n",
+    "cat > tools_extract_embeddings.py << 'PY'\n",
+    "import os, sys, glob, json, re, pathlib, numpy as np, torch\n",
+    "from pathlib import Path\n",
+    "from omegaconf import OmegaConf\n",
+    "sys.path.append(str(Path.cwd()))\n",
+    "# Import TP3D local copy\n",
+    "sys.path.append(str(Path.cwd() / \"torch_points3d\"))\n",
+    "from torch_points3d.metrics.panoptic_tracker import PanopticTracker  # noqa: F401 (forces TP3D import)\n",
+    "from train import hydra_main as train_hydra_main  # to reuse config utils if exposed\n",
+    "from eval import hydra_main as eval_hydra_main    # type: ignore\n",
+    "\n",
+    "# Small utility to load hydra config from conf/eval.yaml\n",
+    "def load_eval_cfg():\n",
+    "    cfg = OmegaConf.load(\"conf/eval.yaml\")\n",
+    "    return cfg\n",
+    "\n",
+    "def find_embed_module(model):\n",
+    "    candidates = []\n",
+    "    for name, m in model.named_modules():\n",
+    "        if \"emb\" in name.lower():\n",
+    "            candidates.append(name)\n",
+    "    return candidates\n",
+    "\n",
+    "def ensure_dir(p): os.makedirs(p, exist_ok=True)\n",
+    "\n",
+    "def dump_npz(out_dir, tag, data_dict):\n",
+    "    ensure_dir(out_dir)\n",
+    "    np.savez_compressed(os.path.join(out_dir, f\"{tag}.npz\"), **data_dict)\n",
+    "\n",
+    "def main():\n",
+    "    import hydra\n",
+    "    from omegaconf import DictConfig\n",
+    "    # Run eval hydra to build model + dataloaders then intercept forward\n",
+    "    @hydra.main(config_path=\"conf\", config_name=\"eval\", version_base=None)\n",
+    "    def _run(cfg: DictConfig):\n",
+    "        # Build model & loaders the same way eval.py does\n",
+    "        # We call the eval hydra entry but override the evaluation loop to attach hooks.\n",
+    "        from eval import build_model_and_loaders  # we expect eval.py to expose helpers; fallback otherwise\n",
+    "        try:\n",
+    "            model, loaders, device, test_split = build_model_and_loaders(cfg)\n",
+    "        except Exception as e:\n",
+    "            print(\"Falling back to importing torch_points3d style builders:\", e)\n",
+    "            # Fallback: try to import internal builders if authors changed names\n",
+    "            raise\n",
+    "\n",
+    "        model.eval()\n",
+    "        model = model.to(device)\n",
+    "\n",
+    "        # Try to discover an embedding head via outputs or module names\n",
+    "        caught = {\"batch_indices\": [], \"embeddings\": []}\n",
+    "        example_name = None\n",
+    "\n",
+    "        # Soft hook mechanism\n",
+    "        chosen_mod = None\n",
+    "        for name, m in model.named_modules():\n",
+    "            if re.search(r\"(emb|embed|embedding)\", name, re.I):\n",
+    "                chosen_mod = m\n",
+    "                chosen_name = name\n",
+    "                break\n",
+    "        hook_handle = None\n",
+    "        if chosen_mod is not None:\n",
+    "            def _hook(module, inp, out):\n",
+    "                # out shape [N, D]\n",
+    "                try:\n",
+    "                    E = out.detach().cpu().float().numpy()\n",
+    "                    caught[\"embeddings\"].append(E)\n",
+    "                except Exception:\n",
+    "                    pass\n",
+    "            hook_handle = chosen_mod.register_forward_hook(lambda m,i,o: _hook(m,i,o))\n",
+    "            print(f\"[extract] Hooked embedding module: {chosen_name}\", flush=True)\n",
+    "        else:\n",
+    "            print(\"[extract] No obvious embedding module found; will try dict outputs.\", flush=True)\n",
+    "\n",
+    "        out_root = Path(\"outputs/embeddings\")\n",
+    "        ensure_dir(out_root)\n",
+    "\n",
+    "        # Iterate over test loader only\n",
+    "        test_loader = loaders.get(test_split, None) or loaders.get(\"test\", None)\n",
+    "        if test_loader is None:\n",
+    "            raise RuntimeError(\"Test loader not found in loaders keys:\", loaders.keys())\n",
+    "\n",
+    "        with torch.no_grad():\n",
+    "            for ib, batch in enumerate(test_loader):\n",
+    "                batch = batch.to(device)\n",
+    "                out = model(batch)\n",
+    "                # If model returns dict with embeddings\n",
+    "                if isinstance(out, dict):\n",
+    "                    for k in [\"embedding\", \"embeddings\", \"embedding_5d\", \"emb_5d\", \"panoptic_embeddings\"]:\n",
+    "                        if k in out and isinstance(out[k], torch.Tensor):\n",
+    "                            E = out[k].detach().cpu().float().numpy()\n",
+    "                            caught[\"embeddings\"].append(E)\n",
+    "                            break\n",
+    "\n",
+    "                # Gather point indices to map back if available\n",
+    "                if hasattr(batch, \"idx\"):\n",
+    "                    idx = batch.idx.detach().cpu().numpy()\n",
+    "                elif hasattr(batch, \"ptr\"):\n",
+    "                    idx = batch.ptr.detach().cpu().numpy()\n",
+    "                else:\n",
+    "                    # fallback: monotonic indices\n",
+    "                    n = out[\"semantic\"].shape[0] if isinstance(out, dict) and \"semantic\" in out else 0\n",
+    "                    idx = np.arange(n, dtype=np.int64)\n",
+    "\n",
+    "                # Flatten and dump per-batch\n",
+    "                if len(caught[\"embeddings\"]) == 0:\n",
+    "                    print(f\"[extract] WARNING: no embeddings captured for batch {ib}.\")\n",
+    "                    continue\n",
+    "                E = caught[\"embeddings\"][-1]\n",
+    "                tag = f\"batch_{ib:05d}\"\n",
+    "                dump_npz(out_root, tag, {\"indices\": idx, \"embeddings\": E})\n",
+    "                print(f\"[extract] Saved embeddings for {tag} -> {E.shape}\", flush=True)\n",
+    "\n",
+    "        if hook_handle is not None:\n",
+    "            hook_handle.remove()\n",
+    "\n",
+    "    _run()\n",
+    "\n",
+    "if __name__ == \"__main__\":\n",
+    "    main()\n",
+    "PY\n",
+    "\n",
+    "echo \"Script tools_extract_embeddings.py created.\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17e12392",
+   "metadata": {},
+   "source": [
+    "## 8) Exécuter l'évaluation et l’extraction d’embeddings\n",
+    "Le script d’éval officiel produit les dossiers `viz_for_test_*`. Ensuite, on extrait les embeddings en suivant **les mêmes splits/scènes**.\n",
+    "\n",
+    "**Remarque:** pense à mettre le chemin du checkpoint (`CKPT_PATH`) si tu n’entraînes pas dans cette session."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59dd1c43",
+   "metadata": {
+    "cellView": "form"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "%%bash\n",
+    "set -euxo pipefail\n",
+    "cd PanopticSegForLargeScalePointCloud\n",
+    "\n",
+    "# Exemple: on veut évaluer Area 1 (Paris en test) en Setting IV (comme dans README)\n",
+    "# Si tu as entraîné ici, adapte CKPT_PATH en conséquence; sinon, place un checkpoint existant à l'endroit indiqué.\n",
+    "CKPT_PATH=\"${CKPT_PATH:-/content/drive/MyDrive/panoptic_runs/A1_S7/checkpoints/best.pth}\" || true\n",
+    "\n",
+    "# Adapter conf/eval.yaml avant de lancer eval.py (les auteurs l'indiquent dans le README).\n",
+    "# Comme on ne connaît pas tes chemins exacts, on te laisse la main:\n",
+    "echo \"Ouvre et adapte conf/eval.yaml si nécessaire (paths, split, ckpt).\"\n",
+    "sed -n '1,160p' conf/eval.yaml || true\n",
+    "\n",
+    "# Lancer l'éval (si eval.py dépend entièrement de conf/eval.yaml)\n",
+    "# python eval.py\n",
+    "\n",
+    "# Ou, si Hydra accepte des overrides, tu peux donner des précisions en CLI (à adapter si besoin) :\n",
+    "# python eval.py task=panoptic data=panoptic/npm3d-sparseconv_grid_012_R_16_cylinder_area1 \\\n",
+    "#   models=panoptic/area4_ablation_3heads_5 model_name=PointGroup-PAPER training=7_area1 \\\n",
+    "#   +eval.ckpt_path=\"$CKPT_PATH\"\n",
+    "\n",
+    "echo \"Extraction des embeddings (utilise conf/eval.yaml et le même loader test)\"\n",
+    "python tools_extract_embeddings.py || true\n",
+    "\n",
+    "echo \"Pour calculer les métriques officielles NPM3D :\"\n",
+    "echo \"python evaluation_stats_NPM3D.py\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89db68eb",
+   "metadata": {},
+   "source": [
+    "## 9) Où sont les embeddings et comment brancher ton clusterer\n",
+    "Les `.npz` sont écrits sous `outputs/embeddings/` avec deux arrays:\n",
+    "- `embeddings`: matrice `[N, 5]` (D=5 attendu) de l’embedding discriminant par point du batch\n",
+    "- `indices`: indices des points pour reconstituer l’ordre si besoin\n",
+    "\n",
+    "### Exemple: brancher un clusterer perso qui prend soit `X` soit une matrice de distances\n",
+    "Le snippet ci-dessous charge tous les `.npz`, concatène, normalise à la volée, applique un clusterer,\n",
+    "puis sauvegarde un `instance_id` par point dans un `.npy`. À toi de remplacer `my_clusterer()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6490a7f6",
+   "metadata": {
+    "cellView": "form"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "import os, glob, numpy as np\n",
+    "from sklearn.preprocessing import StandardScaler\n",
+    "\n",
+    "EMB_DIR = \"PanopticSegForLargeScalePointCloud/outputs/embeddings\"\n",
+    "OUT_PATH = \"PanopticSegForLargeScalePointCloud/outputs/instance_labels.npy\"\n",
+    "\n",
+    "def load_all_embeddings_npz(emb_dir):\n",
+    "    files = sorted(glob.glob(os.path.join(emb_dir, \"*.npz\")))\n",
+    "    Xs, Is = [], []\n",
+    "    for f in files:\n",
+    "        d = np.load(f)\n",
+    "        Xs.append(d[\"embeddings\"])\n",
+    "        Is.append(d[\"indices\"])\n",
+    "    if not Xs:\n",
+    "        raise RuntimeError(\"Aucun fichier d'embedding trouvé dans %s\" % emb_dir)\n",
+    "    X = np.concatenate(Xs, axis=0)\n",
+    "    I = np.concatenate(Is, axis=0)\n",
+    "    return X, I\n",
+    "\n",
+    "def my_clusterer(X):\n",
+    "    # TODO: remplace par ton algo. Ici, on met un stub trivial à 1 cluster.\n",
+    "    # X: [N, d]\n",
+    "    N = X.shape[0]\n",
+    "    labels = np.zeros(N, dtype=np.int32)\n",
+    "    return labels\n",
+    "\n",
+    "X, I = load_all_embeddings_npz(EMB_DIR)\n",
+    "Xn = StandardScaler().fit_transform(X)\n",
+    "labels = my_clusterer(Xn)\n",
+    "np.save(OUT_PATH, labels)\n",
+    "print(\"Saved instance labels to:\", OUT_PATH, \" shape:\", labels.shape)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ae6dbab",
+   "metadata": {},
+   "source": [
+    "## 10) (Facultatif) Remonter tes clusters en PLY et relancer l’éval officielle\n",
+    "Si tu veux remplacer les instances du pipeline par les tiennes, convertis `instance_labels.npy` en `.ply` attendu par `evaluation_stats_NPM3D.py`.\n",
+    "Le format attendu par l’issue #19 indique des champs `pre_sem_label`, `gt_sem_label` et les IDs d’instance prédits/GT. Tu peux partir des sorties de `viz_for_test_valid_proposals` et ne remplacer que la colonne d’instances prédictives."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "539809b2",
+   "metadata": {
+    "cellView": "form"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Exemple de squelette: à adapter selon les champs déjà présents dans vos PLY de sortie\n",
+    "# from plyfile import PlyData, PlyElement\n",
+    "# import numpy as np\n",
+    "# sem_ply = PlyData.read(\"PanopticSegForLargeScalePointCloud/viz_for_test_valid_proposals/instance.ply\")\n",
+    "# labels = np.load(\"PanopticSegForLargeScalePointCloud/outputs/instance_labels.npy\")\n",
+    "# # Construire une nouvelle structure en remplaçant le champ d'instance prédite puis sauvegarder.\n",
+    "# PlyData([ ... ]).write(\"PanopticSegForLargeScalePointCloud/outputs/instance_custom.ply\")\n",
+    "print(\"Voir issue #19 pour les champs consultés par evaluation_stats_NPM3D.py\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0942e1fe",
+   "metadata": {},
+   "source": [
+    "## 11) Lancer l’évaluation finale (scripts officiels)\n",
+    "Les auteurs fournissent `evaluation_stats_NPM3D.py` qui charge les sorties d’éval et calcule F1, PQ, etc."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb32355f",
+   "metadata": {
+    "cellView": "form"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "%%bash\n",
+    "set -euxo pipefail\n",
+    "cd PanopticSegForLargeScalePointCloud\n",
+    "# Pour NPM3D\n",
+    "python evaluation_stats_NPM3D.py || true\n",
+    "# Pour FOR-instance (si utilisé)\n",
+    "# python evaluation_stats_FOR.py\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e2cb4a4",
+   "metadata": {},
+   "source": [
+    "## Notes pratiques\n",
+    "- Les chemins et le checkpoint à utiliser pour l’éval se règlent dans `conf/eval.yaml` ou via des overrides Hydra. Le README fournit les commandes et les noms des configs pour NPM3D, **Setting IV** notamment.\n",
+    "- Le dataset NPM3D avec **labels d’instance** se télécharge depuis Zenodo (12 fichiers .ply). On les place sous `data/npm3dfused/raw/` comme indiqué dans le README.\n",
+    "- Si l’extraction d’embeddings ne capture rien du premier coup, imprime la liste des `model.named_modules()` et choisis un module contenant `emb` pour le hook."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "NPM3D_PanopticSeg_embeddings_and_eval.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- warn when the runtime does not provide PyTorch >= 2.8 in the GPU check cell
- refresh the dependency install cell to align with PyTorch 2.8.0+cu126, install matching PyG wheels and rebuild MinkowskiEngine
- document proxy-friendly configuration knobs and guard the PyG install step against inaccessible wheel indexes

## Testing
- `python -m pip install --no-cache-dir --upgrade hydra-core==1.3.2 omegaconf==2.3.0 plyfile==0.9 scipy==1.11.4 hdbscan==0.8.33 pandas==2.2.2 numba==0.59.1 joblib==1.3.2 tqdm pyyaml packaging`
- `python -m pip install --no-cache-dir --upgrade --extra-index-url https://data.pyg.org/whl/torch-2.8.0+cu128.html torch-scatter==2.1.2 torch-sparse==0.6.18 torch-cluster==1.6.3 torch-geometric==2.6.1` *(fails: proxy blocks access to data.pyg.org, compilation aborted)*

------
https://chatgpt.com/codex/tasks/task_b_68c99d041f148326b4d03c66540f1cd7